### PR TITLE
[SQUASH] Switch to AttestationHooks

### DIFF
--- a/core/java/android/app/Instrumentation.java
+++ b/core/java/android/app/Instrumentation.java
@@ -65,6 +65,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import com.android.internal.util.blaze.PixelPropsUtils;
+import com.android.internal.util.blaze.AttestationHooks;
 
 /**
  * Base class for implementing application instrumentation code.  When running
@@ -1233,6 +1234,7 @@ public class Instrumentation {
         Application app = getFactory(context.getPackageName())
                 .instantiateApplication(cl, className);
         app.attach(context);
+        AttestationHooks.initApplicationBeforeOnCreate(app);
         PixelPropsUtils.setProps(app);
         return app;
     }
@@ -1251,6 +1253,7 @@ public class Instrumentation {
             ClassNotFoundException {
         Application app = (Application)clazz.newInstance();
         app.attach(context);
+        AttestationHooks.initApplicationBeforeOnCreate(app);
         PixelPropsUtils.setProps(app);
         return app;
     }

--- a/core/java/com/android/internal/util/blaze/AttestationHooks.java
+++ b/core/java/com/android/internal/util/blaze/AttestationHooks.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.internal.util.blaze;
+
+import android.app.Application;
+import android.os.Build;
+import android.os.SystemProperties;
+import android.util.Log;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+/** @hide */
+public final class AttestationHooks {
+    private static final String TAG = "AttestationHooks";
+
+    private static final String PACKAGE_GMS = "com.google.android.gms";
+    private static final String PACKAGE_FINSKY = "com.android.vending";
+    private static final String PROCESS_UNSTABLE = "com.google.android.gms.unstable";
+
+    private static volatile boolean sIsGms = false;
+    private static volatile boolean sIsFinsky = false;
+
+    private AttestationHooks() { }
+
+    private static void setBuildField(String key, String value) {
+        try {
+            // Unlock
+            Field field = Build.class.getDeclaredField(key);
+            field.setAccessible(true);
+
+            // Edit
+            field.set(null, value);
+
+            // Lock
+            field.setAccessible(false);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            Log.e(TAG, "Failed to spoof Build." + key, e);
+        }
+    }
+
+    private static void spoofBuildGms() {
+        // Alter model name and fingerprint to avoid hardware attestation enforcement
+        setBuildField("FINGERPRINT", "google/angler/angler:6.0/MDB08L/2343525:user/release-keys");
+        setBuildField("MODEL", "Nexus 6P");
+    }
+
+    public static void initApplicationBeforeOnCreate(Application app) {
+        if (PACKAGE_GMS.equals(app.getPackageName()) &&
+                PROCESS_UNSTABLE.equals(Application.getProcessName())) {
+            sIsGms = true;
+            spoofBuildGms();
+        }
+
+        if (PACKAGE_FINSKY.equals(app.getPackageName())) {
+            sIsFinsky = true;
+        }
+    }
+
+    private static boolean isCallerSafetyNet() {
+        return Arrays.stream(Thread.currentThread().getStackTrace())
+                .anyMatch(elem -> elem.getClassName().contains("DroidGuard"));
+    }
+
+    public static void onEngineGetCertificateChain() {
+        // Check stack for SafetyNet
+        if (sIsGms && isCallerSafetyNet()) {
+            throw new UnsupportedOperationException();
+        }
+
+        // Check stack for PlayIntegrity
+        if (sIsFinsky) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/core/java/com/android/internal/util/blaze/PixelPropsUtils.java
+++ b/core/java/com/android/internal/util/blaze/PixelPropsUtils.java
@@ -29,7 +29,8 @@ import java.util.Map;
 
 public class PixelPropsUtils {
 
-    public static final String PACKAGE_GMS = "com.google.android.gms";
+    private static final String PACKAGE_GMS = "com.google.android.gms";
+    private static final String PACKAGE_FINSKY = "com.android.vending";
     private static final String DEVICE = "org.pixelexperience.device";
     private static final String TAG = PixelPropsUtils.class.getSimpleName();
     private static final boolean DEBUG = false;
@@ -39,7 +40,6 @@ public class PixelPropsUtils {
 
     private static final Map<String, Object> propsToChangePixel5;
     private static final String[] packagesToChangePixel5 = {
-            "com.android.vending",
             "com.google.android.apps.photos",
             "com.google.android.apps.recorder",
             "com.google.android.apps.turbo",
@@ -58,7 +58,6 @@ public class PixelPropsUtils {
     private static final Map<String, ArrayList<String>> propsToKeep;
     private static final String[] extraPackagesToChange = {
             "com.android.chrome",
-            "com.android.vending",
             "com.breel.wallpapers20",
             "com.snapchat.android"
     };
@@ -98,6 +97,8 @@ public class PixelPropsUtils {
     };
 
     private static final String[] packagesToKeep = {
+        PACKAGE_FINSKY,
+        PACKAGE_GMS,
         "com.google.android.GoogleCamera",
         "com.google.android.GoogleCamera.Cameight",
         "com.google.android.GoogleCamera.Go",
@@ -130,8 +131,6 @@ public class PixelPropsUtils {
     };
 
     private static ArrayList<String> allProps = new ArrayList<>(Arrays.asList("BRAND", "MANUFACTURER", "DEVICE", "PRODUCT", "MODEL", "FINGERPRINT"));
-
-    private static volatile boolean sIsGms = false;
 
     static {
         propsToKeep = new HashMap<>();
@@ -178,10 +177,6 @@ public class PixelPropsUtils {
         final String processName = app.getProcessName();
         if (packageName == null) {
             return;
-        }
-        if (packageName.equals(PACKAGE_GMS) &&
-                processName.equals(PACKAGE_GMS + ".unstable")) {
-            sIsGms = true;
         }
         boolean isPixelDevice = Arrays.asList(pixelCodenames).contains(SystemProperties.get(DEVICE));
         if (!isPixelDevice && 
@@ -261,18 +256,6 @@ public class PixelPropsUtils {
             field.setAccessible(false);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             Log.e(TAG, "Failed to set prop " + key, e);
-        }
-    }
-
-    private static boolean isCallerSafetyNet() {
-        return Arrays.stream(Thread.currentThread().getStackTrace())
-                .anyMatch(elem -> elem.getClassName().contains("DroidGuard"));
-    }
-
-    public static void onEngineGetCertificateChain() {
-        // Check stack for SafetyNet
-        if (sIsGms && isCallerSafetyNet()) {
-            throw new UnsupportedOperationException();
         }
     }
 }

--- a/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
+++ b/keystore/java/android/security/keystore2/AndroidKeyStoreSpi.java
@@ -42,6 +42,7 @@ import android.system.keystore2.ResponseCode;
 import android.util.Log;
 
 import com.android.internal.annotations.VisibleForTesting;
+import com.android.internal.util.blaze.AttestationHooks;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -76,8 +77,6 @@ import java.util.List;
 import java.util.Set;
 
 import javax.crypto.SecretKey;
-
-import com.android.internal.util.blaze.PixelPropsUtils;
 
 /**
  * A java.security.KeyStore interface for the Android KeyStore. An instance of
@@ -166,7 +165,7 @@ public class AndroidKeyStoreSpi extends KeyStoreSpi {
 
     @Override
     public Certificate[] engineGetCertificateChain(String alias) {
-        PixelPropsUtils.onEngineGetCertificateChain();
+        AttestationHooks.onEngineGetCertificateChain();
 
         KeyEntryResponse response = getKeyMetadata(alias);
 


### PR DESCRIPTION
Also includes:

Spoof product name for Google Play Services (https://github.com/hentaiOS/platform_frameworks_base/commit/05b3987d7b892ea50ba0eee865fe988c27ae90c1)

NB: This code is under the gmscompat package, but it does not depend on any code from gmscompat.

Change-Id: Ic018c0d7abe4573143c3b92301a2625b91e6673a

keystore: Block key attestation for SafetyNet (https://github.com/hentaiOS/platform_frameworks_base/commit/cac828325ab375775d7e0b0cc39f428ad17e0ea5)

SafetyNet (part of Google Play Services) opportunistically uses hardware-backed key attestation via KeyStore as a strong integrity check. This causes SafetyNet to fail on custom ROMs because the verified boot key and bootloader unlock state can be detected from attestation certificates.

As a workaround, we can take advantage of the fact that SafetyNet's usage of key attestation is opportunistic (i.e. falls back to basic integrity checks if it fails) and prevent it from getting the attestation certificate chain from KeyStore. This is done by checking the stack for DroidGuard, which is the codename for SafetyNet, and pretending that the device doesn't support key attestation.

Key attestation has only been blocked for SafetyNet specifically, as Google Play Services and other apps have many valid reasons to use it. For example, it appears to be involved in Google's mobile security key ferature.

Change-Id: I5146439d47f42dc6231cb45c4dab9f61540056f6

Limit SafetyNet workarounds to unstable GMS process (https://github.com/hentaiOS/platform_frameworks_base/commit/fce9b65304829f16ad9bc87ad0cdd1472cb5a594)

The unstable process is where SafetyNet attestation actually runs, so we only need to spoof the model in that process. Leaving other processes fixes various issues caused by model detection and flag provisioning, including screen-off Voice Match in Google Assistant, broken At a Glance weather and settings on Android 12, and more.

Change-Id: Idcf663907a6c3d0408dbd45b1ac53c9eb4200df8

gmscompat: Apply the SafetyNet workaround to Play Store aswell (https://github.com/hentaiOS/platform_frameworks_base/commit/c9a086f9b635bf4e3e61fbd501ade464f8f5b713)

Play Store is used for the new Play Integrity API, extend the hack to it aswell

Test: Device Integrity and Basic Integrity passes.

Signed-off-by: Dyneteve <dyneteve@hentaios.com>
Change-Id: Id607cdff0b902f285a6c1b769c0a4ee4202842b1

gmscompat: Use Nexus 6P fingerprint for CTS/Integrity (https://github.com/hentaiOS/platform_frameworks_base/commit/813f11628014a93d45f55dedd434fdddd9510eb0)

Google seems to have patched the KM block to Play Store in record time, but is still not enforced for anything under android N.

Since we moved to angler FP we don't need to spoof model to Play Store anymore, however the KM block is still needed.

Test: Run Play Intregrity Attestation

Signed-off-by: Dyneteve <dyneteve@hentaios.com>
Change-Id: Ic2401a6e40ddfc4318a1d0faa87e42eb118ac3d1

Co-authored-by: Dyneteve <dyneteve@hentaios.com>
Signed-off-by: pc1598 <piyushchouhan1598@gmail.com>