### PR TITLE
AuthService: Add support for workaround side fps props

### DIFF
--- a/services/core/java/com/android/server/biometrics/AuthService.java
+++ b/services/core/java/com/android/server/biometrics/AuthService.java
@@ -31,6 +31,8 @@ import static android.hardware.biometrics.BiometricAuthenticator.TYPE_NONE;
 import static android.hardware.biometrics.BiometricConstants.BIOMETRIC_ERROR_CANCELED;
 import static android.hardware.biometrics.BiometricManager.Authenticators;
 
+import static com.android.server.biometrics.sensors.fingerprint.aidl.FingerprintProvider.getWorkaroundSensorProps;
+
 import android.annotation.NonNull;
 import android.annotation.Nullable;
 import android.app.AppOpsManager;
@@ -802,6 +804,10 @@ public class AuthService extends SystemService {
         final int[] udfpsProps = getContext().getResources().getIntArray(
                 com.android.internal.R.array.config_udfps_sensor_props);
 
+	// Non-empty workaroundLocations indicates that the sensor is SFPS.
+        final List<SensorLocationInternal> workaroundLocations =
+                getWorkaroundSensorProps(getContext());
+
         final boolean isUdfps = !ArrayUtils.isEmpty(udfpsProps);
 
         // config_is_powerbutton_fps indicates whether device has a power button fingerprint sensor.
@@ -831,6 +837,12 @@ public class AuthService extends SystemService {
                     resetLockoutRequiresHardwareAuthToken,
                     List.of(new SensorLocationInternal("" /* display */, udfpsProps[0],
                             udfpsProps[1], udfpsProps[2])));
+	} else if (!workaroundLocations.isEmpty()) {
+            return new FingerprintSensorPropertiesInternal(sensorId,
+                    Utils.authenticatorStrengthToPropertyStrength(strength), maxEnrollmentsPerUser,
+                    componentInfo, sensorType, false /* halControlsIllumination */,
+                    resetLockoutRequiresHardwareAuthToken,
+                    workaroundLocations);
         } else {
             return new FingerprintSensorPropertiesInternal(sensorId,
                     Utils.authenticatorStrengthToPropertyStrength(strength), maxEnrollmentsPerUser,

--- a/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/FingerprintProvider.java
+++ b/services/core/java/com/android/server/biometrics/sensors/fingerprint/aidl/FingerprintProvider.java
@@ -97,6 +97,8 @@ import java.util.stream.Collectors;
 @SuppressWarnings("deprecation")
 public class FingerprintProvider implements IBinder.DeathRecipient, ServiceProvider {
 
+    private static final String TAG = "FingerprintProvider";
+
     private boolean mTestHalEnabled;
 
     @NonNull
@@ -218,7 +220,7 @@ public class FingerprintProvider implements IBinder.DeathRecipient, ServiceProvi
     }
 
     private String getTag() {
-        return "FingerprintProvider/" + mHalInstanceName;
+        return TAG + "/" + mHalInstanceName;
     }
 
     boolean hasHalInstance() {
@@ -796,7 +798,7 @@ public class FingerprintProvider implements IBinder.DeathRecipient, ServiceProvi
     // TODO(b/174868353): workaround for gaps in HAL interface (remove and get directly from HAL)
     // reads values via an overlay instead of querying the HAL
     @NonNull
-    private List<SensorLocationInternal> getWorkaroundSensorProps(@NonNull Context context) {
+    public static List<SensorLocationInternal> getWorkaroundSensorProps(@NonNull Context context) {
         final List<SensorLocationInternal> sensorLocations = new ArrayList<>();
 
         final TypedArray sfpsProps = context.getResources().obtainTypedArray(
@@ -817,7 +819,7 @@ public class FingerprintProvider implements IBinder.DeathRecipient, ServiceProvi
     }
 
     @Nullable
-    private SensorLocationInternal parseSensorLocation(@Nullable TypedArray array) {
+    private static SensorLocationInternal parseSensorLocation(@Nullable TypedArray array) {
         if (array == null) {
             return null;
         }
@@ -829,7 +831,7 @@ public class FingerprintProvider implements IBinder.DeathRecipient, ServiceProvi
                     array.getInt(2, 0),
                     array.getInt(3, 0));
         } catch (Exception e) {
-            Slog.w(getTag(), "malformed sensor location", e);
+            Slog.w(TAG, "malformed sensor location", e);
         }
         return null;
     }


### PR DESCRIPTION
HIDL fingerprint implementations have no way of providing this info.